### PR TITLE
refactor: next/script 사용하는 방식으로 변경

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ import { queryClient } from '@/shared/utils/queryClient';
 import { CommonAppLayout } from '@/components/Common';
 import * as gtag from '@/lib/gtag';
 import OgImage from 'public/images/og_image.png';
+import Script from 'next/script';
 
 if (typeof window !== 'undefined') {
   if ('serviceWorker' in navigator) {
@@ -54,6 +55,22 @@ function MyApp({ Component, pageProps }: AppProps) {
         />
         <meta property="og:image" content={OgImage.src} />
       </Head>
+      {/* Global Site Tag (gtag.js) - Google Analytics */}
+      <Script src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`} strategy="afterInteractive" />
+      <Script
+        id="gtag-init"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{
+          __html: `
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gtag.GA_TRACKING_ID}', {
+            page_path: window.location.pathname,
+          });
+        `,
+        }}
+      />
       <QueryClientProvider client={queryClient}>
         <RecoilRoot>
           <ThemeProvider theme={theme}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Document, { DocumentContext, DocumentInitialProps, Html, Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
-import { GA_TRACKING_ID } from '@/lib/gtag';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
@@ -60,20 +59,6 @@ class MyDocument extends Document {
           {/* TODO: 임시 아이콘 변경 */}
           <link rel="icon" type="image/png" sizes="16x16" href="/favicon.png" />
           <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials" />
-          {/* Global Site Tag (gtag.js) - Google Analytics */}
-          <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`} />
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `
-            window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('config', '${GA_TRACKING_ID}', {
-              page_path: window.location.pathname,
-            });
-          `,
-            }}
-          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Description

next/script는 HTML <script> 요소의 확장으로 추가 스크립트를 가져오고 실행할 때 최적화된다고 하여 리팩토링을 하였습니다.

## Changes

아래 링크를 참고하여 수정해보았습니다!
ref. https://github.com/vercel/next.js/blob/canary/examples/with-google-tag-manager/pages/_app.js 
