### PR TITLE
fix: Textarea 컴포넌트 padding 유지를 위해 wrapper 추가

### DIFF
--- a/components/Common/TextArea/TextArea.styles.ts
+++ b/components/Common/TextArea/TextArea.styles.ts
@@ -1,31 +1,35 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { TextAreaProps } from '@/components/Common/TextArea/TextArea';
 import theme from '@/styles/theme';
 
-export const Textarea = styled.textarea<Pick<TextAreaProps, 'height' | 'borderRadius'>>`
-  width: 100%;
+export const TextareaContainer = styled.div<{ borderRadius: string; isFocused: boolean }>`
   padding: 1.6rem 1.8rem 1.8rem 1.8rem;
-  display: inline-block;
-  text-align: start;
-  cursor: text;
-  height: ${({ height }) => height};
   border-radius: ${({ borderRadius }) => borderRadius};
   background: ${theme.colors.gray2};
-  border: none;
-  right: 0;
+  box-sizing: border-box;
+
+  ${({ isFocused }) =>
+    isFocused &&
+    css`
+      border: 0.1rem solid ${theme.colors.gray4};
+    `}
+`;
+
+export const Textarea = styled.textarea<Pick<TextAreaProps, 'height'>>`
+  width: 100%;
+  height: ${({ height }) => height};
   ${theme.fonts.body}
   color: ${theme.colors.white};
+  background: inherit;
+  border: 0;
   outline: none;
   resize: none;
 
-  :focus {
-    border: 0.1rem solid ${theme.colors.gray4};
-  }
   ::placeholder {
     color: ${theme.colors.gray4};
   }
+
   :disabled {
-    color: ${theme.colors.white};
     -webkit-text-fill-color: ${theme.colors.white};
     opacity: 1;
   }

--- a/components/Common/TextArea/TextArea.tsx
+++ b/components/Common/TextArea/TextArea.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Textarea } from './TextArea.styles';
+import { Textarea, TextareaContainer } from './TextArea.styles';
 
 export type TextAreaAttributes = Pick<
   React.TextareaHTMLAttributes<HTMLTextAreaElement>,
@@ -33,20 +33,21 @@ const TextArea = ({
   const [isFocused, setIsFocused] = useState(false);
 
   return (
-    <Textarea
-      value={value}
-      borderRadius={borderRadius}
-      height={height}
-      onFocus={(event: React.FocusEvent<HTMLTextAreaElement>) => {
-        setIsFocused(true);
-        onFocus?.(event);
-      }}
-      onBlur={(event: React.FocusEvent<HTMLTextAreaElement>) => {
-        setIsFocused(false);
-        onBlur?.(event);
-      }}
-      {...restTextAreaProps}
-    />
+    <TextareaContainer borderRadius={borderRadius} isFocused={isFocused}>
+      <Textarea
+        value={value}
+        height={height}
+        onFocus={(event: React.FocusEvent<HTMLTextAreaElement>) => {
+          setIsFocused(true);
+          onFocus?.(event);
+        }}
+        onBlur={(event: React.FocusEvent<HTMLTextAreaElement>) => {
+          setIsFocused(false);
+          onBlur?.(event);
+        }}
+        {...restTextAreaProps}
+      />
+    </TextareaContainer>
   );
 };
 


### PR DESCRIPTION
## Description

Textarea height 가 고정되어있고 텍스트를 고정된 height 보다 많이 작성하는 경우 하단 padding 을 벗어나 텍스트가 노출되는 이슈가 있습니다.

## Changes

- textarea 를 감싸는 container div element 를 추가하고, 해당 element 에 padding 을 추가하였습니다.
- textarea 감싸는 div 에 isFocused 를 props 로 전달하여 포커스 될 때 border style 을 적용하였습니다.

## 스크린샷

**AS-IS**
<img width="594" alt="스크린샷 2022-08-20 오후 2 49 57" src="https://user-images.githubusercontent.com/29244798/185731033-41e1031c-baf6-4dbd-9e33-b11518fa36c9.png">

**TO-BE**
<img width="494" alt="스크린샷 2022-08-20 오후 2 42 38" src="https://user-images.githubusercontent.com/29244798/185731005-f27742f3-5299-4b18-8c1f-bdc0fe14761d.png">

